### PR TITLE
Added Windows 11, plus DirectX 9 or higher into System Requirements section in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use BeatDrop with your favourite
 
 * WASAPI-compatible sound card
 
-* DirectX 9 - compatible GPU
+* DirectX 9 or higher. - compatible GPU
 
 * DirectX End-User [Runtimes](https://www.microsoft.com/en-us/download/details.aspx?id=8109) (also included in the installer) contains the required 32-bit helper libraries d3dx9_43.dll and d3dx9_31.dll
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use BeatDrop with your favourite
   ...
 
 ## System Requirements
-* Windows 10, Windows 8.1 or Windows 7 SP1
+* Windows 11, Windows 10, Windows 8.1 or Windows 7 SP1
 
 * WASAPI-compatible sound card
 


### PR DESCRIPTION
Now works with Windows 11. I should really add this into System Requirements. It really works 100%.